### PR TITLE
fix: rename route placeholders name and stash names to avoid reserved words in Mojolicious

### DIFF
--- a/lib/Dash/Backend/Mojolicious/Setup.pm
+++ b/lib/Dash/Backend/Mojolicious/Setup.pm
@@ -23,21 +23,21 @@ sub register_app {
         '/' => sub {
             my $c = shift;
             $c->stash(
-                stylesheets => $dash_app->()->_rendered_stylesheets,
-                external_stylesheets => $dash_app->()->_rendered_external_stylesheets,
-                scripts => $dash_app->()->_rendered_scripts,
-                title => $dash_app->()->app_name);
+                perl_dash_mojo_backend_stylesheets => $dash_app->()->_rendered_stylesheets,
+                perl_dash_mojo_backend_external_stylesheets => $dash_app->()->_rendered_external_stylesheets,
+                perl_dash_mojo_backend_scripts => $dash_app->()->_rendered_scripts,
+                perl_dash_mojo_backend_title => $dash_app->()->app_name);
             $c->render( template => 'index' );
         }
     );
 
     my $dist_name = 'Dash';
-    $routes->get('/_dash-component-suites/:namespace/*asset' => sub {
+    $routes->get('/_dash-component-suites/:perl_dash_mojo_backend_namespace/*perl_dash_mojo_backend_asset' => sub {
             # TODO Component registry to find assets file in other dists
             my $c = shift;
-            my $file = $dash_app->()->_filename_from_file_with_fingerprint($c->stash('asset'));
+            my $file = $dash_app->()->_filename_from_file_with_fingerprint($c->stash('perl_dash_mojo_backend_asset'));
 
-            $c->reply->file(File::ShareDir::dist_file($dist_name, Path::Tiny::path('assets', $c->stash('namespace'), $file)->canonpath ));
+            $c->reply->file(File::ShareDir::dist_file($dist_name, Path::Tiny::path('assets', $c->stash('perl_dash_mojo_backend_namespace'), $file)->canonpath ));
         } 
     );
 
@@ -103,7 +103,7 @@ __DATA__
 </div>
 
         <footer>
-            <%== $scripts %>
+            <%== $perl_dash_mojo_backend_scripts %>
         </footer>
 
 
@@ -113,10 +113,10 @@ __DATA__
     <head>
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
       <meta charset="UTF-8">
-        <title><%= $title %></title>
+        <title><%= $perl_dash_mojo_backend_title %></title>
         <link rel="icon" type="image/x-icon" href="/_favicon.ico?v=1.7.0">
-        <%== $stylesheets %>
-        <%== $external_stylesheets %>
+        <%== $perl_dash_mojo_backend_stylesheets %>
+        <%== $perl_dash_mojo_backend_external_stylesheets %>
     </head>
     <body>
         


### PR DESCRIPTION
Since Mojolicious 9.0 route placeholders are checked for reserved names. Those names are prefixed now with to avoid conflict and possible future conflicts.

Fix #2 